### PR TITLE
Documentation cleanup

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 # AI2 API for Peer Review Management
 
-The [Allen Institute for AI](http://allenai.org) offers an API to aid conference chairs with matching conference submissions with potential reviewers.
+As part of its public API, the [Allen Institute for AI](http://allenai.org) offers a service to aid conference chairs with matching conference submissions with potential reviewers.
 
-The full API documentation can be found [here](https://partner.semanticscholar.org/v1/peer-review).
+The full documentation can be found [here](https://partner.semanticscholar.org/v1/peer-review).
 
-This repo implements a simple command-line client for convenient access to the API. The provided API key gives access to a shared account for limited trial use. 
+This repo implements a simple command-line client for convenient access to the service. The provided API key gives access to a shared account for limited trial use. 
 
 For full access to the API, contact our [partner team](https://pages.semanticscholar.org/data-partners). There is no charge for non-commercial use. Restrictions may apply to commercial use.
 

--- a/peer_review/api_client.py
+++ b/peer_review/api_client.py
@@ -23,4 +23,4 @@ class ApiClient():
 
 
 def client():
-    return ApiClient(f"{config.get('host')}/peer-review", config.get('api_key'))
+    return ApiClient(f"{config.get('url')}", config.get('api_key'))

--- a/peer_review/config.py
+++ b/peer_review/config.py
@@ -31,8 +31,8 @@ def configure():
             return input(f"{msg}:")
 
     api_key = prompt("Enter API Key", "api_key", "zq83r8JXjm1azwm0rmA5l6EMAE80sgfK8u3clGFL")
-    host = prompt("Enter host", "host", "http://conference-api.prod.s2.allenai.org")
-    _config = {'api_key': api_key, 'host': host}
+    url = prompt("Enter service URL", "url", "http://api.semanticscholar.org/v1/peer-review")
+    _config = {'api_key': api_key, 'url': url}
 
     with open(os.path.join(os.path.dirname(__file__), '.config'), 'w') as f:
         json.dump(_config, f)


### PR DESCRIPTION
https://github.com/allenai/scholar/issues/28130

Replace "API" with "service" in documentation text. Use `api.semanticscholar.org` domain.